### PR TITLE
Remove MakeGlobalVariablesScript hook

### DIFF
--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -40,10 +40,6 @@ if ( $wgWikiTideCommons ?? false && !$cwPrivate ) {
 	wfLoadExtension( 'GlobalUsage' );
 }
 
-if ( $wi->isAnyOfExtensionsActive( 'SearchVue', 'Upload Wizard' ) ) {
-	wfLoadExtension( 'EventLogging' );
-}
-
 if ( $wi->isExtensionActive( 'InterwikiSorting' ) ) {
 	$wgInterwikiSortingInterwikiSortOrders = include __DIR__ . '/InterwikiSortOrders.php';
 }


### PR DESCRIPTION
This can be pulled from matomo now with https://github.com/WikiForge/MediaWikiDebugJS/commit/452df6b012c73b9635f103215d7ec5e73c3bcf7d